### PR TITLE
gitのバージョン表記を一部修正

### DIFF
--- a/Chap1.md
+++ b/Chap1.md
@@ -83,7 +83,7 @@ brew --version
 結果として
 
 ```
-Homebrew 4.0.10
+Homebrew 4.0.19
 Homebrew/homebrew-core (git revision 29f317deb32; last commit 2023-04-03)
 Homebrew/homebrew-cask (git revision 4602819837; last commit 2023-04-03)
 ```


### PR DESCRIPTION
## :cyclone: なぜ修正するのか

バージョン違いによる誤解を防ぐため

## :cyclone: 具体的にやったこと

最新バージョンでコマンド実行
