### PR TITLE
リンク名を記載

### DIFF
--- a/Chap1.md
+++ b/Chap1.md
@@ -126,7 +126,7 @@ https://xtech.nikkei.com/atcl/learning/column/19/00014/
 
 まず以下の資料で`git`の意味と使い方の基礎を学びましょう。
 
-https://backlog.com/ja/git-tutorial/
+[サル先生のGit入門]https://backlog.com/ja/git-tutorial/
 
 入門編、発展編、プルリクエスト編の全てに目を通しましょう。
 

--- a/Chap1.md
+++ b/Chap1.md
@@ -126,7 +126,7 @@ https://xtech.nikkei.com/atcl/learning/column/19/00014/
 
 まず以下の資料で`git`の意味と使い方の基礎を学びましょう。
 
-<a target="_blank" href="https://backlog.com/ja/git-tutorial/">サル先生のGit入門</a>
+<a href="https://backlog.com/ja/git-tutorial/" target="_blank">サル先生のGit入門</a>
 
 入門編、発展編、プルリクエスト編の全てに目を通しましょう。
 

--- a/Chap1.md
+++ b/Chap1.md
@@ -126,7 +126,7 @@ https://xtech.nikkei.com/atcl/learning/column/19/00014/
 
 まず以下の資料で`git`の意味と使い方の基礎を学びましょう。
 
-[サル先生のGit入門]https://backlog.com/ja/git-tutorial/
+[サル先生のGit入門](https://backlog.com/ja/git-tutorial/)
 
 入門編、発展編、プルリクエスト編の全てに目を通しましょう。
 

--- a/Chap1.md
+++ b/Chap1.md
@@ -126,7 +126,7 @@ https://xtech.nikkei.com/atcl/learning/column/19/00014/
 
 まず以下の資料で`git`の意味と使い方の基礎を学びましょう。
 
-[サル先生のGit入門](https://backlog.com/ja/git-tutorial/)
+[サル先生のGit入門](https://backlog.com/ja/git-tutorial/){:target="_blank"}
 
 入門編、発展編、プルリクエスト編の全てに目を通しましょう。
 

--- a/Chap1.md
+++ b/Chap1.md
@@ -126,7 +126,7 @@ https://xtech.nikkei.com/atcl/learning/column/19/00014/
 
 まず以下の資料で`git`の意味と使い方の基礎を学びましょう。
 
-[サル先生のGit入門](https://backlog.com/ja/git-tutorial/){:target="_blank"}
+<a target="_blank" href="https://backlog.com/ja/git-tutorial/">サル先生のGit入門</a>
 
 入門編、発展編、プルリクエスト編の全てに目を通しましょう。
 


### PR DESCRIPTION
## :cyclone: なぜ修正するのか

- リンクのURLよりもリンク先名の方がページの移動先が正しいことが分かりやすい。

## :cyclone: 具体的にやったこと

- URLからリンク先の名前に変更

## :cyclone: 確認前のチェック事項

- [x] Markdownはちゃんと描画されているか