### PR TITLE
brewでinstallしたgitにPATHを通す必要がある旨の記述

### DIFF
--- a/Chap1.md
+++ b/Chap1.md
@@ -73,7 +73,9 @@ brew install git
 git --version
 ```
 
-結果として`git version 2.30.1 (Apple Git-130)`のような文字列が表示されたら、キホンの環境構築はOKです！
+この時、`git version 2.30.1`のような文字列のあとに`(Apple Git-130)`などといった文字列が表示されている場合は、Homebrewでインストールしたgitではなく、Macにデフォルトで入っているgitが使われています。
+そのため、HomebrewでインストールしたGitにパスを通す必要があります。
+結果として`git version 2.42.0`のような文字列が表示されたら、キホンの環境構築はOKです！
 
 ### Linux
 


### PR DESCRIPTION
## :cyclone: なぜ修正するのか

- Macにはデフォルトでgitが入っているらしく、brewで新たにgitをinstallしても、もとからあるgitの方が優先されるらしい
  - 
- brewでinstallした最新のgitを使うには、PATHを通す必要がある

## :cyclone: 具体的にやったこと

- その旨を追記

## :cyclone: 参考にしたサイト

- https://www.webdesignleaves.com/pr/plugins/git-setup-mac.html
- https://qiita.com/normalsalt/items/f200ba50363ebfd46df0

## :cyclone: 考えないといけないこと

- PATHの通し方まで懇切丁寧に記述すべきか否か
  - 通し方は各自で調べてもらう方が良いか？
- そもそもデフォルトで入っているのだから、わざわざbrewでinstallする必要があるか？
  - 最新版を使うにはbrewでinstallする必要があるっぽい

## :cyclone: 確認前のチェック事項

- [ ] Markdownはちゃんと描画されているか