### PR TITLE
リンク切れしていたURLを、別のサイトのURLに書き換えました。

### DIFF
--- a/Chap1.md
+++ b/Chap1.md
@@ -222,7 +222,7 @@ ssh -T git@github.com
 Hi (account名)! You've successfully authenticated, but GitHub does not provide shell access.
 ```
 
-できない場合は、https://www.kagoya.jp/howto/it-glossary/develop/github_ssh/を参考にSSHで接続できるようにしましょう！
+できない場合は、https://qiita.com/shizuma/items/2b2f873a0034839e47ceを参考にSSHで接続できるようにしましょう！
 
 Q3. `github`で、[こちらの記事](https://docs.github.com/ja/get-started/quickstart/create-a-repo)を参考にしてリポジトリを作成しましょう。また、そのリポジトリに`README.md`を作成しましょう。
 


### PR DESCRIPTION
## :cyclone: なぜ修正するのか

一部のリンク(sshでgithubにアクセスするところの解説記事)の飛ぶ先のサイトが利用できなくなっていたため。

## :cyclone: 具体的にやったこと

リンクを、現在利用可能な別のサイトのものに書き換えた。

## :cyclone: 確認前のチェック事項

- [ ☑] Markdownはちゃんと描画されているか